### PR TITLE
fixing pandas X.iloc[X] Dataset getitem method

### DIFF
--- a/061_self_attention/.ipynb_checkpoints/self_attention-checkpoint.ipynb
+++ b/061_self_attention/.ipynb_checkpoints/self_attention-checkpoint.ipynb
@@ -93,7 +93,7 @@
     "    return len(self.X)\n",
     "\n",
     "  def __getitem__(self, ix):\n",
-    "    return torch.tensor(self.X[ix]).float(), torch.tensor(self.y[ix]).long()\n",
+    "    return torch.tensor(self.X.iloc[ix]).float(), torch.tensor(self.y[ix]).long()\n",
     "\n",
     "class MNISTDataModule(pl.LightningDataModule):\n",
     "\n",


### PR DESCRIPTION
I was getting a "KeyError" in the 3rd code cell every time in colab and also in VSCode notebooks and finally I could solve it by changing self.X[ix] to self.X.iloc[ix] because they KeyError was from here as pandas wasn't able to get the row item, to get it without the iloc it needs to be at least a slice, not a single row number from what I tested. It is strange because apparently it worked before with the original code but at least for now I had to apply iloc, loc or slicing to get it. BTW, Thanks for your amazing work sensio!!